### PR TITLE
Added logging to games shared between sac and ppo

### DIFF
--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DAgent.cs
@@ -66,7 +66,7 @@ public class Ball3DAgent : Agent
             SetReward(0.1f);
         }
         // Add next line
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     public override void OnEpisodeBegin()

--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
@@ -66,7 +66,7 @@ public class Ball3DHardAgent : Agent
         {
             SetReward(0.1f);
         }
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     public override void OnEpisodeBegin()

--- a/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/3DBall/Scripts/Ball3DHardAgent.cs
@@ -15,6 +15,7 @@ public class Ball3DHardAgent : Agent
         m_BallRb = ball.GetComponent<Rigidbody>();
         m_ResetParams = Academy.Instance.EnvironmentParameters;
         SetResetParameters();
+        base.InitializeLoggingVariables();
     }
 
     [Observable(numStackedObservations: 9)]
@@ -38,6 +39,7 @@ public class Ball3DHardAgent : Agent
     public override void OnActionReceived(ActionBuffers actionBuffers)
 
     {
+        base.CheckAndLogFirstPart();
         var continuousActions = actionBuffers.ContinuousActions;
         var actionZ = 2f * Mathf.Clamp(continuousActions[0], -1f, 1f);
         var actionX = 2f * Mathf.Clamp(continuousActions[1], -1f, 1f);
@@ -64,6 +66,7 @@ public class Ball3DHardAgent : Agent
         {
             SetReward(0.1f);
         }
+        base.ManageStepCount();
     }
 
     public override void OnEpisodeBegin()
@@ -74,6 +77,7 @@ public class Ball3DHardAgent : Agent
         m_BallRb.velocity = new Vector3(0f, 0f, 0f);
         ball.transform.position = new Vector3(Random.Range(-1.5f, 1.5f), 4f, Random.Range(-1.5f, 1.5f))
             + gameObject.transform.position;
+        base.LogEpisodeTime();
     }
 
     public void SetBall()

--- a/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Crawler/Scripts/CrawlerAgent.cs
@@ -198,7 +198,7 @@ public class CrawlerAgent : Agent
         bpDict[leg1Lower].SetJointStrength(continuousActions[++i]);
         bpDict[leg2Lower].SetJointStrength(continuousActions[++i]);
         bpDict[leg3Lower].SetJointStrength(continuousActions[++i]);
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     void FixedUpdate()

--- a/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/FoodCollector/Scripts/FoodCollectorAgent.cs
@@ -189,7 +189,7 @@ public class FoodCollectorAgent : Agent
     {
         base.CheckAndLogFirstPart();
         MoveAgent(actionBuffers);
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     public override void Heuristic(in ActionBuffers actionsOut)

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -165,7 +165,7 @@ public class GridAgent : Agent
                 EndEpisode();
             }
         }
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     private void ProvideReward(GridGoal hitObject)

--- a/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/GridWorld/Scripts/GridAgent.cs
@@ -72,6 +72,7 @@ public class GridAgent : Agent
     {
         m_GoalSensor = this.GetComponent<VectorSensorComponent>();
         m_ResetParams = Academy.Instance.EnvironmentParameters;
+        base.InitializeLoggingVariables();
     }
 
     public override void CollectObservations(VectorSensor sensor)
@@ -121,6 +122,7 @@ public class GridAgent : Agent
     public override void OnActionReceived(ActionBuffers actionBuffers)
 
     {
+        base.CheckAndLogFirstPart();
         AddReward(-0.01f);
         var action = actionBuffers.DiscreteActions[0];
 
@@ -163,6 +165,7 @@ public class GridAgent : Agent
                 EndEpisode();
             }
         }
+        base.ManageStepCount();
     }
 
     private void ProvideReward(GridGoal hitObject)
@@ -212,6 +215,7 @@ public class GridAgent : Agent
         {
             CurrentGoal = GridGoal.GreenPlus;
         }
+        base.LogEpisodeTime();
     }
 
     public void FixedUpdate()

--- a/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
@@ -76,7 +76,7 @@ public class HallwayAgent : Agent
         base.CheckAndLogFirstPart();
         AddReward(-1f / MaxStep);
         MoveAgent(actionBuffers.DiscreteActions);
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     void OnCollisionEnter(Collision col)

--- a/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Hallway/Scripts/HallwayAgent.cs
@@ -27,6 +27,7 @@ public class HallwayAgent : Agent
         m_GroundRenderer = ground.GetComponent<Renderer>();
         m_GroundMaterial = m_GroundRenderer.material;
         m_statsRecorder = Academy.Instance.StatsRecorder;
+        base.InitializeLoggingVariables();
     }
 
     public override void CollectObservations(VectorSensor sensor)
@@ -72,8 +73,10 @@ public class HallwayAgent : Agent
     public override void OnActionReceived(ActionBuffers actionBuffers)
 
     {
+        base.CheckAndLogFirstPart();
         AddReward(-1f / MaxStep);
         MoveAgent(actionBuffers.DiscreteActions);
+        base.ManageStepCount();
     }
 
     void OnCollisionEnter(Collision col)
@@ -161,5 +164,6 @@ public class HallwayAgent : Agent
         }
         m_statsRecorder.Add("Goal/Correct", 0, StatAggregationMethod.Sum);
         m_statsRecorder.Add("Goal/Wrong", 0, StatAggregationMethod.Sum);
+        base.LogEpisodeTime();
     }
 }

--- a/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
+++ b/Project/Assets/ML-Agents/Examples/PushBlock/Scripts/PushAgentBasic.cs
@@ -175,7 +175,7 @@ public class PushAgentBasic : Agent
 
         // Penalty given each step to encourage agent to finish task quickly.
         AddReward(-1f / MaxStep);
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     public override void Heuristic(in ActionBuffers actionsOut)

--- a/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidAgent.cs
@@ -63,7 +63,7 @@ public class PyramidAgent : Agent
         base.CheckAndLogFirstPart();
         AddReward(-1f / MaxStep);
         MoveAgent(actionBuffers.DiscreteActions);
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     public override void Heuristic(in ActionBuffers actionsOut)

--- a/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Pyramids/Scripts/PyramidAgent.cs
@@ -20,6 +20,7 @@ public class PyramidAgent : Agent
         m_AgentRb = GetComponent<Rigidbody>();
         m_MyArea = area.GetComponent<PyramidArea>();
         m_SwitchLogic = areaSwitch.GetComponent<PyramidSwitch>();
+        base.InitializeLoggingVariables();
     }
 
     public override void CollectObservations(VectorSensor sensor)
@@ -59,8 +60,10 @@ public class PyramidAgent : Agent
     public override void OnActionReceived(ActionBuffers actionBuffers)
 
     {
+        base.CheckAndLogFirstPart();
         AddReward(-1f / MaxStep);
         MoveAgent(actionBuffers.DiscreteActions);
+        base.ManageStepCount();
     }
 
     public override void Heuristic(in ActionBuffers actionsOut)
@@ -102,6 +105,7 @@ public class PyramidAgent : Agent
         m_MyArea.CreateStonePyramid(1, items[6]);
         m_MyArea.CreateStonePyramid(1, items[7]);
         m_MyArea.CreateStonePyramid(1, items[8]);
+        base.LogEpisodeTime();
     }
 
     void OnCollisionEnter(Collision collision)

--- a/Project/Assets/ML-Agents/Examples/Sorter/Scripts/SorterAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Sorter/Scripts/SorterAgent.cs
@@ -42,6 +42,7 @@ public class SorterAgent : Agent
         m_BufferSensor = GetComponent<BufferSensorComponent>();
         m_AgentRb = GetComponent<Rigidbody>();
         m_StartingPos = transform.position;
+        base.InitializeLoggingVariables();
     }
 
     public override void OnEpisodeBegin()
@@ -55,6 +56,7 @@ public class SorterAgent : Agent
         transform.position = m_StartingPos;
         m_AgentRb.velocity = Vector3.zero;
         m_AgentRb.angularVelocity = Vector3.zero;
+        base.LogEpisodeTime();
     }
 
 
@@ -228,11 +230,13 @@ public class SorterAgent : Agent
     public override void OnActionReceived(ActionBuffers actionBuffers)
 
     {
+        base.CheckAndLogFirstPart();
         // Move the agent using the action.
         MoveAgent(actionBuffers.DiscreteActions);
 
         // Penalty given each step to encourage agent to finish task quickly.
         AddReward(-1f / MaxStep);
+        base.ManageStepCount();
     }
 
     public override void Heuristic(in ActionBuffers actionsOut)

--- a/Project/Assets/ML-Agents/Examples/Sorter/Scripts/SorterAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Sorter/Scripts/SorterAgent.cs
@@ -236,7 +236,7 @@ public class SorterAgent : Agent
 
         // Penalty given each step to encourage agent to finish task quickly.
         AddReward(-1f / MaxStep);
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     public override void Heuristic(in ActionBuffers actionsOut)

--- a/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
@@ -202,7 +202,7 @@ public class WalkerAgent : Agent
         bpDict[forearmL].SetJointStrength(continuousActions[++i]);
         bpDict[armR].SetJointStrength(continuousActions[++i]);
         bpDict[forearmR].SetJointStrength(continuousActions[++i]);
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     //Update OrientationCube and DirectionIndicator

--- a/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Walker/Scripts/WalkerAgent.cs
@@ -84,6 +84,7 @@ public class WalkerAgent : Agent
         m_JdController.SetupBodyPart(handR);
 
         m_ResetParams = Academy.Instance.EnvironmentParameters;
+        base.InitializeLoggingVariables();
     }
 
     /// <summary>
@@ -105,6 +106,7 @@ public class WalkerAgent : Agent
         //Set our goal walking speed
         MTargetWalkingSpeed =
             randomizeWalkSpeedEachEpisode ? Random.Range(0.1f, m_maxWalkingSpeed) : MTargetWalkingSpeed;
+        base.LogEpisodeTime();
     }
 
     /// <summary>
@@ -165,6 +167,7 @@ public class WalkerAgent : Agent
     public override void OnActionReceived(ActionBuffers actionBuffers)
 
     {
+        base.CheckAndLogFirstPart();
         var bpDict = m_JdController.bodyPartsDict;
         var i = -1;
 
@@ -199,6 +202,7 @@ public class WalkerAgent : Agent
         bpDict[forearmL].SetJointStrength(continuousActions[++i]);
         bpDict[armR].SetJointStrength(continuousActions[++i]);
         bpDict[forearmR].SetJointStrength(continuousActions[++i]);
+        base.ManageStepCount();
     }
 
     //Update OrientationCube and DirectionIndicator

--- a/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
@@ -262,7 +262,7 @@ public class WallJumpAgent : Agent
             StartCoroutine(
                 GoalScoredSwapGroundMaterial(m_WallJumpSettings.failMaterial, .5f));
         }
-        base.ManageStepCount();
+        // base.ManageStepCount();
     }
 
     public override void Heuristic(in ActionBuffers actionsOut)

--- a/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/WallJump/Scripts/WallJumpAgent.cs
@@ -78,6 +78,7 @@ public class WallJumpAgent : Agent
             bigWallBrain = modelOverrider.GetModelForBehaviorName(m_BigWallBehaviorName);
             m_BigWallBehaviorName = ModelOverrider.GetOverrideBehaviorName(m_BigWallBehaviorName);
         }
+        base.InitializeLoggingVariables();
     }
 
     // Begin the jump sequence
@@ -250,6 +251,7 @@ public class WallJumpAgent : Agent
     public override void OnActionReceived(ActionBuffers actionBuffers)
 
     {
+        base.CheckAndLogFirstPart();
         MoveAgent(actionBuffers.DiscreteActions);
         if ((!Physics.Raycast(m_AgentRb.position, Vector3.down, 20))
             || (!Physics.Raycast(m_ShortBlockRb.position, Vector3.down, 20)))
@@ -260,6 +262,7 @@ public class WallJumpAgent : Agent
             StartCoroutine(
                 GoalScoredSwapGroundMaterial(m_WallJumpSettings.failMaterial, .5f));
         }
+        base.ManageStepCount();
     }
 
     public override void Heuristic(in ActionBuffers actionsOut)
@@ -311,6 +314,7 @@ public class WallJumpAgent : Agent
             18 * (Random.value - 0.5f), 1, -12);
         m_Configuration = Random.Range(0, 5);
         m_AgentRb.velocity = default(Vector3);
+        base.LogEpisodeTime();
     }
 
     void FixedUpdate()

--- a/Project/Assets/ML-Agents/Examples/Worm/Scripts/WormAgent.cs
+++ b/Project/Assets/ML-Agents/Examples/Worm/Scripts/WormAgent.cs
@@ -43,6 +43,7 @@ public class WormAgent : Agent
         m_JdController.SetupBodyPart(bodySegment1);
         m_JdController.SetupBodyPart(bodySegment2);
         m_JdController.SetupBodyPart(bodySegment3);
+        base.InitializeLoggingVariables();
     }
 
 
@@ -70,6 +71,7 @@ public class WormAgent : Agent
         bodySegment0.rotation = Quaternion.Euler(0, Random.Range(0.0f, 360.0f), 0);
 
         UpdateOrientationObjects();
+        base.LogEpisodeTime();
     }
 
     /// <summary>
@@ -135,6 +137,7 @@ public class WormAgent : Agent
 
     public override void OnActionReceived(ActionBuffers actionBuffers)
     {
+        base.CheckAndLogFirstPart();
         // The dictionary with all the body parts in it are in the jdController
         var bpDict = m_JdController.bodyPartsDict;
 

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -1442,13 +1442,15 @@ namespace Unity.MLAgents
 
         public void CheckAndLogFirstPart()
         {
+            if (stepCount > frequency) stepCount = 0;
             if (stepCount == 0)
             {
                 logger.LogStepTimeAndStepPerSecond();
                 logger.LogPerformanceData();
                 logger.LogTimeElapsed();
             }
-            ManageStepCount();
+            stepCount++;
+            // ManageStepCount();
         }
 
         public void LogEpisodeTime()
@@ -1456,11 +1458,11 @@ namespace Unity.MLAgents
             logger.LogEpisodeTime();
         }
 
-        public void ManageStepCount()
-        {
-            stepCount++;
-            if (stepCount >= frequency) stepCount = 0;
-        }
+        // private void ManageStepCount()
+        // {
+        //     stepCount++;
+        //     if (stepCount > frequency) stepCount = 0;
+        // }
 
         public PerformanceLogger Logger
         {

--- a/com.unity.ml-agents/Runtime/Agent.cs
+++ b/com.unity.ml-agents/Runtime/Agent.cs
@@ -1448,6 +1448,7 @@ namespace Unity.MLAgents
                 logger.LogPerformanceData();
                 logger.LogTimeElapsed();
             }
+            ManageStepCount();
         }
 
         public void LogEpisodeTime()
@@ -1459,6 +1460,11 @@ namespace Unity.MLAgents
         {
             stepCount++;
             if (stepCount >= frequency) stepCount = 0;
+        }
+
+        public PerformanceLogger Logger
+        {
+            get { return logger; }
         }
     }
 }


### PR DESCRIPTION
Added logging from chsarp to 3dBallHard, Grid, Hallway, Pyramid, Sorter, Walker, WallJump, WormAgent. I didn't add logging to Basic game, as the class doesn't inherit from Agent class, and requires different tactic than all the other games. Also the BasicController.cs file used for the game Basic is an example of "How **not** to do it" - it is inefficient and poorly done, so I suppose we are not going to use it for training our ML models.

### Proposed change(s)
Implemented changes from issue #72  into 4 other games.
Also fixed a bug I introduced in first commit - stepcount was increased twice per each step (bug in Agent.cs). 

### Types of change(s)

- [x] Bug fix
- [x] New feature
- [ ] Code refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)